### PR TITLE
Add git-lfs to deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apk update && \
   apk add \
     build-base \
     git \
+    git-lfs \
     mercurial \
     bzr \
     go && \


### PR DESCRIPTION
Maybe needed for some project since LFS start to be used by more projects. My main use case is to be able to test LFS functions of gitea from git client but it can also be needed to build some golang project that use git lfs.