### PR TITLE
drop bzr

### DIFF
--- a/edge/Dockerfile.amd64
+++ b/edge/Dockerfile.amd64
@@ -16,7 +16,7 @@ ENV GO111MODULE auto
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   rm -rf /var/cache/apk/*
 
 COPY ./overlay ./overlay-amd64 /

--- a/edge/Dockerfile.arm32v6
+++ b/edge/Dockerfile.arm32v6
@@ -16,7 +16,7 @@ ENV GO111MODULE auto
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   rm -rf /var/cache/apk/*
 
 COPY ./overlay ./overlay-arm32v6 /

--- a/edge/Dockerfile.arm64v8
+++ b/edge/Dockerfile.arm64v8
@@ -16,7 +16,7 @@ ENV GO111MODULE auto
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   rm -rf /var/cache/apk/*
 
 COPY ./overlay ./overlay-arm64v8 /

--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -18,7 +18,7 @@ COPY ./overlay ./overlay-amd64 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/latest/Dockerfile.arm32v6
+++ b/latest/Dockerfile.arm32v6
@@ -18,7 +18,7 @@ COPY ./overlay ./overlay-arm32v6 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ COPY ./overlay ./overlay-arm64v8 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.10/Dockerfile.amd64
+++ b/v1.10/Dockerfile.amd64
@@ -17,7 +17,7 @@ COPY ./overlay ./overlay-amd64 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.10/Dockerfile.arm32v6
+++ b/v1.10/Dockerfile.arm32v6
@@ -17,7 +17,7 @@ COPY ./overlay ./overlay-arm32v6 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.10/Dockerfile.arm64v8
+++ b/v1.10/Dockerfile.arm64v8
@@ -17,7 +17,7 @@ COPY ./overlay ./overlay-arm64v8 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.11/Dockerfile.amd64
+++ b/v1.11/Dockerfile.amd64
@@ -18,7 +18,7 @@ COPY ./overlay ./overlay-amd64 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.11/Dockerfile.arm32v6
+++ b/v1.11/Dockerfile.arm32v6
@@ -18,7 +18,7 @@ COPY ./overlay ./overlay-arm32v6 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.11/Dockerfile.arm64v8
+++ b/v1.11/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ COPY ./overlay ./overlay-arm64v8 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.12/Dockerfile.amd64
+++ b/v1.12/Dockerfile.amd64
@@ -18,7 +18,7 @@ COPY ./overlay ./overlay-amd64 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.12/Dockerfile.arm32v6
+++ b/v1.12/Dockerfile.arm32v6
@@ -18,7 +18,7 @@ COPY ./overlay ./overlay-arm32v6 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.12/Dockerfile.arm64v8
+++ b/v1.12/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ COPY ./overlay ./overlay-arm64v8 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.13/Dockerfile.amd64
+++ b/v1.13/Dockerfile.amd64
@@ -18,7 +18,7 @@ COPY ./overlay ./overlay-amd64 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.13/Dockerfile.arm32v6
+++ b/v1.13/Dockerfile.arm32v6
@@ -18,7 +18,7 @@ COPY ./overlay ./overlay-arm32v6 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.13/Dockerfile.arm64v8
+++ b/v1.13/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ COPY ./overlay ./overlay-arm64v8 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.6/Dockerfile.amd64
+++ b/v1.6/Dockerfile.amd64
@@ -17,7 +17,7 @@ COPY ./overlay ./overlay-amd64 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.6/Dockerfile.arm32v6
+++ b/v1.6/Dockerfile.arm32v6
@@ -17,7 +17,7 @@ COPY ./overlay ./overlay-arm32v6 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.6/Dockerfile.arm64v8
+++ b/v1.6/Dockerfile.arm64v8
@@ -17,7 +17,7 @@ COPY ./overlay ./overlay-arm64v8 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.7/Dockerfile.amd64
+++ b/v1.7/Dockerfile.amd64
@@ -17,7 +17,7 @@ COPY ./overlay ./overlay-amd64 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.7/Dockerfile.arm32v6
+++ b/v1.7/Dockerfile.arm32v6
@@ -17,7 +17,7 @@ COPY ./overlay ./overlay-arm32v6 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.7/Dockerfile.arm64v8
+++ b/v1.7/Dockerfile.arm64v8
@@ -17,7 +17,7 @@ COPY ./overlay ./overlay-arm64v8 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.8/Dockerfile.amd64
+++ b/v1.8/Dockerfile.amd64
@@ -17,7 +17,7 @@ COPY ./overlay ./overlay-amd64 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.8/Dockerfile.arm32v6
+++ b/v1.8/Dockerfile.arm32v6
@@ -17,7 +17,7 @@ COPY ./overlay ./overlay-arm32v6 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.8/Dockerfile.arm64v8
+++ b/v1.8/Dockerfile.arm64v8
@@ -17,7 +17,7 @@ COPY ./overlay ./overlay-arm64v8 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.9/Dockerfile.amd64
+++ b/v1.9/Dockerfile.amd64
@@ -17,7 +17,7 @@ COPY ./overlay ./overlay-amd64 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold protoc && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold protoc && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.9/Dockerfile.arm32v6
+++ b/v1.9/Dockerfile.arm32v6
@@ -17,7 +17,7 @@ COPY ./overlay ./overlay-arm32v6 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \

--- a/v1.9/Dockerfile.arm64v8
+++ b/v1.9/Dockerfile.arm64v8
@@ -17,7 +17,7 @@ COPY ./overlay ./overlay-arm64v8 /
 
 RUN apk update && \
   apk upgrade && \
-  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial bzr go protoc protobuf-dev binutils-gold && \
+  apk add gcc musl-dev openssl openssh-client make git git-lfs mercurial go protoc protobuf-dev binutils-gold && \
   export GOROOT_BOOTSTRAP="$(go env GOROOT)" && \
   export GOOS="$(go env GOOS)" && \
   export GOARCH="$(go env GOARCH)" && \


### PR DESCRIPTION
was dropped upstream https://pkgs.alpinelinux.org/package/edge/community/x86/bzr
also see https://hub.docker.com/r/praekeltfoundation/alpine-buildpack-deps/

> `*bzr` was [removed](https://github.com/docker-library/buildpack-deps/pull/66) from the latest buildpack-deps variants. Starting with Alpine 3.7, `bzr` is not present in alpine-buildpack-deps either.